### PR TITLE
Refactor Tomcat shutdown logic to use dependency injection

### DIFF
--- a/src/main/java/io/openshift/booster/BoosterApplication.java
+++ b/src/main/java/io/openshift/booster/BoosterApplication.java
@@ -15,8 +15,12 @@
  */
 package io.openshift.booster;
 
+import io.openshift.booster.service.TomcatShutdown;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomizer;
+import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory;
+import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class BoosterApplication {
@@ -24,4 +28,21 @@ public class BoosterApplication {
     public static void main(String[] args) {
         SpringApplication.run(BoosterApplication.class, args);
     }
+
+    // Customize servlet container so that we could stop Tomcat when requested.
+
+    @Bean
+    public EmbeddedServletContainerCustomizer embeddedServletContainerCustomizer(TomcatShutdown tomcatShutdown) {
+        return container -> {
+            if (container instanceof TomcatEmbeddedServletContainerFactory) {
+                ((TomcatEmbeddedServletContainerFactory) container).addContextCustomizers(tomcatShutdown::setContext);
+            }
+        };
+    }
+
+    @Bean
+    public TomcatShutdown tomcatShutdown() {
+        return new TomcatShutdown();
+    }
+
 }

--- a/src/main/java/io/openshift/booster/service/GreetingController.java
+++ b/src/main/java/io/openshift/booster/service/GreetingController.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2016-2017 Red Hat, Inc, and individual contributors.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/io/openshift/booster/service/ShutdownController.java
+++ b/src/main/java/io/openshift/booster/service/ShutdownController.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2016-2017 Red Hat, Inc, and individual contributors.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,39 +15,24 @@
  */
 package io.openshift.booster.service;
 
-import java.util.logging.Logger;
-
-import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomizer;
-import org.springframework.boot.context.embedded.tomcat.TomcatContextCustomizer;
-import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory;
-import org.springframework.context.annotation.Bean;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api")
 public class ShutdownController {
-    private static Logger log = Logger.getLogger(ShutdownController.class.getName());
 
-    private ShutdownHook shutdownHook;
+    private final TomcatShutdown tomcatShutdown;
+
+    @Autowired
+    public ShutdownController(TomcatShutdown tomcatShutdown) {
+        this.tomcatShutdown = tomcatShutdown;
+    }
 
     @RequestMapping("/killme")
     public void shutdown() throws Exception {
-        log.info("Shutting down server ...");
-        shutdownHook.shutdown();
+        tomcatShutdown.shutdown();
     }
 
-    @Bean
-    public EmbeddedServletContainerCustomizer getContainerCustomizer() {
-        return container -> {
-            if (container instanceof TomcatEmbeddedServletContainerFactory) {
-                TomcatEmbeddedServletContainerFactory tcContainer = (TomcatEmbeddedServletContainerFactory) container;
-                tcContainer.addContextCustomizers((TomcatContextCustomizer) context -> ShutdownController.this.shutdownHook = new TomcatShutdownHook(context));
-            } else {
-                ShutdownController.this.shutdownHook = () -> {
-                    System.exit(0); // TODO -- add other web servers support instead, if needed
-                };
-            }
-        };
-    }
 }

--- a/src/main/java/io/openshift/booster/service/TomcatShutdown.java
+++ b/src/main/java/io/openshift/booster/service/TomcatShutdown.java
@@ -1,41 +1,45 @@
 /*
  * Copyright 2016-2017 Red Hat, Inc, and individual contributors.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.openshift.booster.service;
 
 import org.apache.catalina.Context;
+import org.apache.catalina.LifecycleException;
 
-interface ShutdownHook {
-    void shutdown() throws Exception;
-}
+public class TomcatShutdown {
 
-class TomcatShutdownHook implements ShutdownHook {
     private Context context;
 
-    TomcatShutdownHook(Context context) {
+    public void setContext(Context context) {
         this.context = context;
     }
 
-    public void shutdown() throws Exception {
-        new Thread(() -> {
-            try {
-                context.stop();
-            } catch (Exception e) {
-                throw new IllegalStateException(e);
-            }
-        }).start();
-    }
-}
+    public void shutdown() {
+        if (context == null) {
+            System.out.println("Tomcat context was not registered. Stopping JVM instead.");
+            System.exit(0);
+        }
 
+        try {
+            System.out.println("Stopping Tomcat context.");
+            context.stop();
+        } catch (LifecycleException e) {
+            System.out.println("Error when stopping Tomcat context. Stopping JVM instead.");
+            System.exit(0);
+        }
+    }
+
+}

--- a/src/test/java/io/openshift/booster/AbstractBoosterApplicationTest.java
+++ b/src/test/java/io/openshift/booster/AbstractBoosterApplicationTest.java
@@ -15,28 +15,13 @@
  */
 package io.openshift.booster;
 
-import static com.jayway.awaitility.Awaitility.await;
-import static com.jayway.restassured.RestAssured.get;
 import static com.jayway.restassured.RestAssured.given;
 import static com.jayway.restassured.RestAssured.when;
 import static org.hamcrest.core.Is.is;
 
-import java.util.concurrent.TimeUnit;
-
-import org.junit.FixMethodOrder;
 import org.junit.Test;
-import org.junit.runners.MethodSorters;
 
-@FixMethodOrder(MethodSorters.NAME_ASCENDING) // When testing locally, application is not restarted, so execute kill test last
 public abstract class AbstractBoosterApplicationTest {
-
-    static boolean isAlive() {
-        try {
-            return get("/health").getStatusCode() == 200;
-        } catch (Exception e) {
-            return false;
-        }
-    }
 
     @Test
     public void testGreetingEndpoint() {
@@ -56,13 +41,4 @@ public abstract class AbstractBoosterApplicationTest {
                 .body("content", is("Hello, John!"));
     }
 
-    @Test
-    public void testKillMeEndpoint() {
-        when().get("/api/killme")
-                .then()
-                .statusCode(200);
-
-        await("Await for the application to die").atMost(5, TimeUnit.MINUTES)
-                .until(() -> !isAlive());
-    }
 }


### PR DESCRIPTION
@alesj , I've refactored Tomcat shutdown logic so that its bits could be injected and mocked. As a result, I was able to add mock to the local test, so that we wouldn't need to rely on the test order.
Could you review the commit?