### PR TITLE
Remove F8 annotations, prometheus port. Remove expose = true annotati…

### DIFF
--- a/.openshiftio/application.yaml
+++ b/.openshiftio/application.yaml
@@ -1,10 +1,16 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: launchpad-builder
+  name: spring-boot-health-check
   annotations:
-    description: This template creates a Build Configuration using an S2I builder.
-    tags: instant-app
+    iconClass: icon-spring
+    tags: spring-boot, health check, java, microservice
+    openshift.io/display-name: Spring Boot - Health checking of the application
+    openshift.io/provider-display-name: "Red Hat, Inc."
+    openshift.io/documentation-url: "https://appdev.prod-preview.openshift.io/docs/spring-boot-runtime.html#mission-health-check-spring-boot-tomcat"
+    description: >-
+      When you deploy an application, its important to know if it is available and if it can start handling incoming requests. Implementing the health check pattern allows you to monitor the health of an application,
+      which includes if an application is available and whether it is able to service requests.
 parameters:
 - name: SOURCE_REPOSITORY_URL
   description: The source URL for the application
@@ -59,14 +65,13 @@ objects:
     output:
       to:
         kind: ImageStreamTag
-        name: spring-boot-health-check:11
+        name: spring-boot-health-check:BOOSTER_VERSION
     postCommit: {}
     resources: {}
     source:
       git:
         uri: ${SOURCE_REPOSITORY_URL}
         ref: ${SOURCE_REPOSITORY_REF}
-      #contextDir: ${SOURCE_REPOSITORY_DIR}
       type: Git
     strategy:
       sourceStrategy:
@@ -96,20 +101,10 @@ objects:
 - apiVersion: v1
   kind: Service
   metadata:
-    annotations:
-      fabric8.io/scm-con-url: scm:git:https://github.com/openshiftio/booster-parent.git/spring-boot-health-check
-      prometheus.io/port: "9779"
-      fabric8.io/scm-url: https://github.com/openshiftio/spring-boot-health-check
-      fabric8.io/iconUrl: img/icons/spring-boot.svg
-      fabric8.io/git-branch: sb-1.5.x
-      prometheus.io/scrape: "true"
-      fabric8.io/scm-devcon-url: scm:git:git:@github.com:openshiftio/booster-parent.git/spring-boot-health-check
-      fabric8.io/scm-tag: booster-parent-11
     labels:
-      expose: "true"
       app: spring-boot-health-check
-      provider: fabric8
-      version: "11"
+      provider: snowdrop
+      version: BOOSTER_VERSION
       group: io.openshift.booster
     name: spring-boot-health-check
   spec:
@@ -120,23 +115,15 @@ objects:
       targetPort: 8080
     selector:
       app: spring-boot-health-check
-      provider: fabric8
+      provider: snowdrop
       group: io.openshift.booster
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
-    annotations:
-      fabric8.io/metrics-path: dashboard/file/kubernetes-pods.json/?var-project=spring-boot-health-check&var-version=11
-      fabric8.io/scm-con-url: scm:git:https://github.com/openshiftio/booster-parent.git/spring-boot-health-check
-      fabric8.io/scm-url: https://github.com/openshiftio/spring-boot-health-check
-      fabric8.io/iconUrl: img/icons/spring-boot.svg
-      fabric8.io/git-branch: sb-1.5.x
-      fabric8.io/scm-devcon-url: scm:git:git:@github.com:openshiftio/booster-parent.git/spring-boot-health-check
-      fabric8.io/scm-tag: booster-parent-11
     labels:
       app: spring-boot-health-check
-      provider: fabric8
-      version: "11"
+      provider: snowdrop
+      version: BOOSTER_VERSION
       group: io.openshift.booster
     name: spring-boot-health-check
   spec:
@@ -144,7 +131,7 @@ objects:
     revisionHistoryLimit: 2
     selector:
       app: spring-boot-health-check
-      provider: fabric8
+      provider: snowdrop
       group: io.openshift.booster
     strategy:
       rollingParams:
@@ -152,18 +139,10 @@ objects:
       type: Rolling
     template:
       metadata:
-        annotations:
-          fabric8.io/metrics-path: dashboard/file/kubernetes-pods.json/?var-project=spring-boot-health-check&var-version=11
-          fabric8.io/scm-con-url: scm:git:https://github.com/openshiftio/booster-parent.git/spring-boot-health-check
-          fabric8.io/scm-url: https://github.com/openshiftio/spring-boot-health-check
-          fabric8.io/iconUrl: img/icons/spring-boot.svg
-          fabric8.io/git-branch: sb-1.5.x
-          fabric8.io/scm-devcon-url: scm:git:git:@github.com:openshiftio/booster-parent.git/spring-boot-health-check
-          fabric8.io/scm-tag: booster-parent-11
         labels:
           app: spring-boot-health-check
-          provider: fabric8
-          version: "11"
+          provider: snowdrop
+          version: BOOSTER_VERSION
           group: io.openshift.booster
       spec:
         containers:
@@ -172,7 +151,7 @@ objects:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          image: spring-boot-health-check:11
+          image: spring-boot-health-check:BOOSTER_VERSION
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 2
@@ -213,15 +192,15 @@ objects:
         - spring-boot
         from:
           kind: ImageStreamTag
-          name: spring-boot-health-check:11
+          name: spring-boot-health-check:BOOSTER_VERSION
       type: ImageChange
 - apiVersion: v1
   kind: Route
   metadata:
     labels:
       app: spring-boot-health-check
-      provider: fabric8
-      version: "11"
+      provider: snowdrop
+      version: BOOSTER_VERSION
       group: io.openshift.booster
     name: spring-boot-health-check
   spec:

--- a/.openshiftio/application.yaml
+++ b/.openshiftio/application.yaml
@@ -53,10 +53,10 @@ objects:
     name: runtime
   spec:
     tags:
-    - name: latest
+    - name: "RUNTIME_VERSION"
       from:
         kind: DockerImage
-        name: registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift
+        name: registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:RUNTIME_VERSION
 - apiVersion: v1
   kind: BuildConfig
   metadata:
@@ -77,7 +77,7 @@ objects:
       sourceStrategy:
         from:
           kind: ImageStreamTag
-          name: runtime:latest
+          name: runtime:RUNTIME_VERSION
         incremental: true
         env:
         - name: MAVEN_ARGS_APPEND
@@ -104,7 +104,7 @@ objects:
     labels:
       app: spring-boot-health-check
       provider: snowdrop
-      version: BOOSTER_VERSION
+      version: "BOOSTER_VERSION"
       group: io.openshift.booster
     name: spring-boot-health-check
   spec:
@@ -123,7 +123,7 @@ objects:
     labels:
       app: spring-boot-health-check
       provider: snowdrop
-      version: BOOSTER_VERSION
+      version: "BOOSTER_VERSION"
       group: io.openshift.booster
     name: spring-boot-health-check
   spec:
@@ -142,7 +142,7 @@ objects:
         labels:
           app: spring-boot-health-check
           provider: snowdrop
-          version: BOOSTER_VERSION
+          version: "BOOSTER_VERSION"
           group: io.openshift.booster
       spec:
         containers:
@@ -200,7 +200,7 @@ objects:
     labels:
       app: spring-boot-health-check
       provider: snowdrop
-      version: BOOSTER_VERSION
+      version: "BOOSTER_VERSION"
       group: io.openshift.booster
     name: spring-boot-health-check
   spec:


### PR DESCRIPTION
- Remove F8 annotations
- Label fabric8 provider replaced by snowdrop
- Prometheus port removed as we don't use it
- Remose expose = true
- Replace the hard coded version within the template with a keyword. Proposition : use as keyword BOOSTER_VERSION for the booster version
- Improve Template metadata