### PR TITLE
tests: replaced junit with junit-vintaje

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,11 +29,11 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>
-    <maven-failsafe-plugin.version>2.19.1</maven-failsafe-plugin.version>
+    <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+    <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
     <arquillian.version>1.4.0.Final</arquillian.version>
     <arquillian-cube.version>1.18.2</arquillian-cube.version>
-    <junit.version>4.13.2</junit.version>
+    <junit-vintaje.version>5.6.3</junit-vintaje.version>
     <spring-boot.version>2.4.9</spring-boot.version>
     <ubi.version>1.3</ubi.version>
     <fabric8.generator.from>
@@ -150,9 +150,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>${junit-vintaje.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
and the failsafe and surefire plugins back to 2.22.2

The goal is to solve the `java.lang.ClassNotFoundException: dev.snowdrop.example.service.GreetingProperties` errors.

```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running dev.snowdrop.example.OpenShiftIT
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.038 sec <<< FAILURE! - in dev.snowdrop.example.OpenShiftIT
initializationError(dev.snowdrop.example.OpenShiftIT)  Time elapsed: 0.005 sec  <<< ERROR!
java.lang.NoClassDefFoundError: dev/snowdrop/example/service/GreetingProperties
Caused by: java.lang.ClassNotFoundException: dev.snowdrop.example.service.GreetingProperties
```