### PR TITLE
chore: established default encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,8 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
     <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <arquillian.version>1.4.0.Final</arquillian.version>
     <arquillian-cube.version>1.18.2</arquillian-cube.version>
     <junit-vintaje.version>5.6.3</junit-vintaje.version>


### PR DESCRIPTION
Project QA was failing with the following error:

```
[WARNING] File encoding has not been set, using platform encoding ANSI_X3.4-1968. Build is platform dependent!
[WARNING] See https://maven.apache.org/general.html#encoding-warning 
[WARNING] Using platform encoding (ANSI_X3.4-1968 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] Using 'null' encoding to copy filtered properties files.
[INFO] Copying 1 resource
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  5.709 s
[INFO] Finished at: 2021-10-25T12:33:38Z
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-resources-plugin:3.2.0:resources (default-resources) on project health-check: Input length = 1 -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-resources-plugin:3.2.0:resources (default-resources) on project health-check: Input length = 1
...
Caused by: java.nio.charset.MalformedInputException: Input length = 1
at java.nio.charset.CoderResult.throwException (CoderResult.java:281)
...
```

Added default UTF-8 encoding to the maven build.

Reference: https://github.com/spring-projects/spring-boot/issues/24346