### PR TITLE
Shorten liveness probe to behave as in the template

### DIFF
--- a/.openshiftio/application.yaml
+++ b/.openshiftio/application.yaml
@@ -208,7 +208,7 @@ objects:
               path: /actuator/health
               port: 8080
               scheme: HTTP
-            initialDelaySeconds: 60
+            initialDelaySeconds: 120
             periodSeconds: 3
             timeoutSeconds: 1
           name: spring-boot

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,7 @@ management.endpoints.web.exposure.include=health,info
 # Dekorate does not support profiles. See https://github.com/dekorateio/dekorate/pull/824
 dekorate.openshift.expose=true
 dekorate.s2i.builder-image=registry.access.redhat.com/ubi8/openjdk-8:1.3
+dekorate.openshift.liveness-probe.initial-delay-seconds=120
+dekorate.openshift.liveness-probe.period-seconds=3
+dekorate.openshift.liveness-probe.timeout-seconds=1
+dekorate.openshift.liveness-probe.failure-threshold=2

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -19,7 +19,7 @@
             <p>Demonstrates how the Kubernetes health checks work to determine if a container is still alive (the <em>liveness</em>          of the container) and ready to serve the traffic for the HTTP endpoints of the application (the <em>readiness</em>          of the container).</p>
           </div>
           <div class="paragraph">
-            <p>To demonstrate this behavior, the application configures a <code>/health</code> HTTP endpoint, which is used by Kubernetes
+            <p>To demonstrate this behavior, the application configures a <code>/actuator/health</code> HTTP endpoint, which is used by Kubernetes
               to issue HTTP requests. If the container is still alive—​which means the Health HTTP endpoint is able to reply—​the
               management platform will receive HTTP code 200 as a response, and no further action is taken. After you click the
               <code>Stop Service</code> button, the HTTP endpoint stops returning a response, and the platform then restarts the pod


### PR DESCRIPTION
- Increase initial delay seconds (in my environment, the app took around 60 seconds and hence the platform was restarting it)
- Same liveness configuration in the template and in dekorate: Now, the app will take up to 20-30 seconds to restart.
- Update the index.html to use `actuator/health`