### PR TITLE
bump dekorate 2.11.5 and removed default maven settings on dekorate OCP

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Build Project using Dekorate
         run: |
           oc new-project dekorate
-          ./run_tests_with_dekorate_in_ocp.sh
+          ./run_tests_with_dekorate_in_ocp.sh -s .github/mvn-settings.xml
       - name: Delete Project using Dekorate
         run: oc delete project dekorate
       - name: Clean folder

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <spring-boot.version>2.7.2</spring-boot.version>
-    <dekorate.version>2.11.4</dekorate.version>
+    <dekorate.version>2.11.5</dekorate.version>
 
     <!-- Overriden from Spring Boot -->
     <tomcat.version>9.0.65</tomcat.version>

--- a/run_tests_with_dekorate_in_ocp.sh
+++ b/run_tests_with_dekorate_in_ocp.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # Run Tests
-eval "./mvnw -s .github/mvn-settings.xml clean verify -Popenshift,openshift-it $@"
+eval "./mvnw clean verify -Popenshift,openshift-it $@"


### PR DESCRIPTION
* bump dekorate 2.11.5
* removed Maven Settings from defaulting on the `run_tests_with_dekorate_in_ocp.sh` script

`Automated from ansible update-examples-upstream-versions-playbook`